### PR TITLE
Add clean up button to experiment

### DIFF
--- a/src/MadnessInteractiveReloaded/Graphics/Systems/DecalSystem.cs
+++ b/src/MadnessInteractiveReloaded/Graphics/Systems/DecalSystem.cs
@@ -60,10 +60,7 @@ public class DecalSystem : Walgelijk.System
 #if DEBUG
         if (Input.IsKeyPressed(Key.F9))
         {
-            foreach (var item in allDecals)
-                Scene.RemoveEntity(item.Entity);
-            foreach (var renderer in decalRenderers)
-                renderer.Clear();
+            RemoveAllDecals(allDecals, decalRenderers);
             return;
         }
 #endif
@@ -105,5 +102,23 @@ public class DecalSystem : Walgelijk.System
 
             renderer.ProcessingIndex = 0;
         }
+    }
+
+    /// <summary>
+    /// Clear all decals.<br></br>The parameters are only used if you already have cached lists of <see cref="DecalComponent"/>s and <see cref="DecalRendererComponent"/>.
+    /// <br></br>
+    /// Otherwise, this method will perform a lookup anyway.
+    /// </summary>
+    /// <param name="allDecals"></param>
+    /// <param name="decalRenderers"></param>
+    public void RemoveAllDecals(IEnumerable<DecalComponent>? allDecals = null, IEnumerable<DecalRendererComponent>? decalRenderers = null)
+    {
+        allDecals ??= Scene.GetAllComponentsOfType<DecalComponent>();
+        decalRenderers ??= Scene.GetAllComponentsOfType<DecalRendererComponent>();
+
+        foreach (var item in allDecals)
+            Scene.RemoveEntity(item.Entity);
+        foreach (var renderer in decalRenderers)
+            renderer.Clear();
     }
 }

--- a/src/MadnessInteractiveReloaded/base/locale/en-GB.json
+++ b/src/MadnessInteractiveReloaded/base/locale/en-GB.json
@@ -49,6 +49,7 @@
     "experiment-header-stngs": "Settings",
     "experiment-modifiers": "Modifiers",
     "experiment-timescale": "Timescale",
+    "experiment-cleanup": "Clean Up Everything",
     "experiment-autospawn": "Autospawn",
     "experiment-spawn-interval": "Spawn interval",
     "experiment-max-enemies": "Max. enemies",

--- a/src/MadnessInteractiveReloaded/base/locale/en-GB.json
+++ b/src/MadnessInteractiveReloaded/base/locale/en-GB.json
@@ -49,7 +49,7 @@
     "experiment-header-stngs": "Settings",
     "experiment-modifiers": "Modifiers",
     "experiment-timescale": "Timescale",
-    "experiment-cleanup": "Clean Up Everything",
+    "experiment-cleanup": "Clean everything",
     "experiment-autospawn": "Autospawn",
     "experiment-spawn-interval": "Spawn interval",
     "experiment-max-enemies": "Max. enemies",


### PR DESCRIPTION
Fixes: #https://github.com/studio-minus/madness-interactive-reloaded/issues/75

![image](https://github.com/user-attachments/assets/bd8ad641-f853-4fb0-ab3a-e821ee32df87)
