### PR TITLE
Fix bug with dragging a weapon while exiting edit mode in Experiment

### DIFF
--- a/src/MadnessInteractiveReloaded/Level/Systems/ExperimentModeSystem.cs
+++ b/src/MadnessInteractiveReloaded/Level/Systems/ExperimentModeSystem.cs
@@ -145,6 +145,7 @@ public class ExperimentModeSystem : Walgelijk.System
         else
         {
             exp.TimeSinceMenuOpened = 0;
+            exp.CurrentlyPlacing = null;
             if (Input.IsKeyReleased(Key.R) && !playerCharacter.IsAlive)
                 MadnessCommands.Revive();
         }


### PR DESCRIPTION
1.)  open editor mode, 
2.) grab a weapon, drag it. 
3.) keep holding the mouse button, and exit edit mode the thumbnail will still be on your cursor

this fixes that