### PR TITLE
Fix level transition pause bug

### DIFF
--- a/src/MadnessInteractiveReloaded/Animation/Systems/AnimationSystem.cs
+++ b/src/MadnessInteractiveReloaded/Animation/Systems/AnimationSystem.cs
@@ -9,9 +9,10 @@ public class AnimationSystem : Walgelijk.System
 {
     public override void Update()
     {
-        if (MadnessUtils.IsPaused(Scene) || MadnessUtils.EditingInExperimentMode(Scene) || MadnessUtils.IsCutscenePlaying(Scene))
+        if (MadnessUtils.EditingInExperimentMode(Scene) || MadnessUtils.IsCutscenePlaying(Scene))
             return;
 
+        if(!MadnessUtils.IsPaused(Scene))
         foreach (var animation in Scene.GetAllComponentsOfType<AnimationComponent>())
         {
             var transform = Scene.GetComponentFrom<TransformComponent>(animation.Entity);
@@ -77,6 +78,8 @@ public class AnimationSystem : Walgelijk.System
 
         foreach (var animation in Scene.GetAllComponentsOfType<BackgroundOffsetAnimationComponent>())
         {
+            if (MadnessUtils.IsPaused(Scene) && animation.AffectedByTimeScale)
+                continue;
             var background = Scene.GetComponentFrom<Background.BackgroundComponent>(animation.Entity);
             var t = Utilities.Clamp(animation.CurrentPlaybackTime / animation.Duration);
 
@@ -96,7 +99,7 @@ public class AnimationSystem : Walgelijk.System
                 background.Offset = animation.OffsetCurve.Evaluate(t);
 
             if (animation.IsPlaying)
-                animation.CurrentPlaybackTime += Time.DeltaTime;
+                animation.CurrentPlaybackTime += animation.AffectedByTimeScale ? Time.DeltaTime : Time.DeltaTimeUnscaled;
         }
     }
 }

--- a/src/MadnessInteractiveReloaded/Graphics/Components/BackgroundOffsetAnimationComponent.cs
+++ b/src/MadnessInteractiveReloaded/Graphics/Components/BackgroundOffsetAnimationComponent.cs
@@ -29,6 +29,11 @@ public class BackgroundOffsetAnimationComponent : Component
     public bool FillForwards = true;
 
     /// <summary>
+    /// If the animation speed is affected by the <see cref="Time.TimeScale"/>. If off, also plays while the scene is paused.
+    /// </summary>
+    public bool AffectedByTimeScale = true;
+
+    /// <summary>
     /// How long the animation has played.
     /// </summary>
     public float CurrentPlaybackTime;

--- a/src/MadnessInteractiveReloaded/Prefabs/Prefabs.cs
+++ b/src/MadnessInteractiveReloaded/Prefabs/Prefabs.cs
@@ -1010,6 +1010,7 @@ public static class Prefabs
         {
             IsPlaying = true,
             Duration = duration,
+            AffectedByTimeScale = false,
             OffsetCurve =
                 type == Transition.Entry
                     ? new Vec2Curve(


### PR DESCRIPTION
made the level transition animation unaffected by the timescale and pausing, so you cant get stuck on a black screen if you pause at the wrong time