### PR TITLE
Linux: don't use `explorer` + compilation fix

### DIFF
--- a/src/MadnessInteractiveReloaded/MIR.csproj
+++ b/src/MadnessInteractiveReloaded/MIR.csproj
@@ -42,11 +42,11 @@
 	</PropertyGroup>
 	
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="MIR --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(OutDir)" />
+		<Exec Command=".\MIR --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(OutDir)" />
 	</Target>
 	
 	<Target Name="PostPublish" AfterTargets="Publish">
-		<Exec Command="MIR --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(PublishDir)" />
+		<Exec Command=".\MIR --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(PublishDir)" />
 	</Target>
 
 	<ItemGroup>

--- a/src/MadnessInteractiveReloaded/Program.cs
+++ b/src/MadnessInteractiveReloaded/Program.cs
@@ -134,7 +134,21 @@ public static class Program
             WriteSystems(systemDumpPath);
             WriteLog(logDumpPath);
 
-            System.Diagnostics.Process.Start("explorer", $"\"{presentationPath}\"");
+            string executable;
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                executable = "explorer";
+            }
+            else if(System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+            {
+                executable = "open";
+            }
+            else
+            {
+                executable = "xdg-open";
+            }
+
+            System.Diagnostics.Process.Start(executable, $"\"{presentationPath}\"");
 
             return;
         }

--- a/src/MadnessInteractiveReloaded/Program.cs
+++ b/src/MadnessInteractiveReloaded/Program.cs
@@ -134,21 +134,7 @@ public static class Program
             WriteSystems(systemDumpPath);
             WriteLog(logDumpPath);
 
-            string executable;
-            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
-            {
-                executable = "explorer";
-            }
-            else if(System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
-            {
-                executable = "open";
-            }
-            else
-            {
-                executable = "xdg-open";
-            }
-
-            System.Diagnostics.Process.Start(executable, $"\"{presentationPath}\"");
+            MadnessUtils.OpenExplorer($"\"{presentationPath}\"");
 
             return;
         }

--- a/src/MadnessInteractiveReloaded/Shared/MadnessUtils.cs
+++ b/src/MadnessInteractiveReloaded/Shared/MadnessUtils.cs
@@ -1,5 +1,4 @@
 ﻿using MIR.LevelEditor.Objects;
-using OpenTK.Windowing.Common.Input;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -68,18 +67,32 @@ public static class MadnessUtils
         return false;
     }
 
+    public static void OpenExplorer(string path)
+    {
+        string executable;
+
+        if (OperatingSystem.IsWindows())
+            executable = "explorer";
+        else if (OperatingSystem.IsMacOS())
+            executable = "open";
+        else
+            executable = "xdg-open";
+
+        System.Diagnostics.Process.Start(executable, path);
+    }
+
     public static Matrix4x4 Invert(this Matrix4x4 matrix)
     {
         if (Matrix4x4.Invert(matrix, out var inverted))
             return inverted;
-        return matrix * -1; //?????????
+        return matrix;
     }
 
     public static Matrix3x2 Invert(this Matrix3x2 matrix)
     {
         if (Matrix3x2.Invert(matrix, out var inverted))
             return inverted;
-        return matrix * -1; //wtf is dit
+        return matrix;
     }
 
     /// <summary>

--- a/src/MadnessInteractiveReloaded/Shared/MadnessUtils.cs
+++ b/src/MadnessInteractiveReloaded/Shared/MadnessUtils.cs
@@ -75,10 +75,33 @@ public static class MadnessUtils
             executable = "explorer";
         else if (OperatingSystem.IsMacOS())
             executable = "open";
-        else
+        else if (OperatingSystem.IsLinux())
             executable = "xdg-open";
+        else return;
 
         System.Diagnostics.Process.Start(executable, path);
+    }
+
+    public static void OpenBrowser(string url)
+    {
+        try
+        {
+            System.Diagnostics.Process.Start(url);
+        }
+        catch (Exception)
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                url = url.Replace("&", "^&");
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("cmd", $"/c start {url}") { CreateNoWindow = true });
+            }
+            else if (OperatingSystem.IsMacOS())
+                System.Diagnostics.Process.Start("open", url);
+            else if (OperatingSystem.IsLinux())
+                System.Diagnostics.Process.Start("xdg-open", url);
+            else
+                throw;
+        }
     }
 
     public static Matrix4x4 Invert(this Matrix4x4 matrix)

--- a/src/MadnessInteractiveReloaded/User interface/Systems/InformationGuiSystem.cs
+++ b/src/MadnessInteractiveReloaded/User interface/Systems/InformationGuiSystem.cs
@@ -1,4 +1,5 @@
-﻿using Walgelijk;
+﻿using System.IO;
+using Walgelijk;
 using Walgelijk.Localisation;
 using Walgelijk.Onion;
 using Walgelijk.SimpleDrawing;
@@ -51,22 +52,6 @@ Original soundtrack
         Ui.Theme.OutlineWidth(2).Once();
         Ui.Layout.Size(170, 40).StickRight().StickBottom().Move(-10, -10);
         if (Ui.ClickButton(Localisation.Get("Open source libraries")))
-        {
-            string executable;
-            if (global::System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(global::System.Runtime.InteropServices.OSPlatform.Windows))
-            {
-                executable = "explorer";
-            }
-            else if(global::System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(global::System.Runtime.InteropServices.OSPlatform.OSX))
-            {
-                executable = "open";
-            }
-            else
-            {
-                executable = "xdg-open";
-            }
-            
-            global::System.Diagnostics.Process.Start(executable, $"\"{Game.ExecutableDirectory}NOTICE.txt\"");
-        }
+            MadnessUtils.OpenExplorer('"' + Path.Combine(Game.ExecutableDirectory, "NOTICE.txt") + '"');
     }
 }

--- a/src/MadnessInteractiveReloaded/User interface/Systems/InformationGuiSystem.cs
+++ b/src/MadnessInteractiveReloaded/User interface/Systems/InformationGuiSystem.cs
@@ -52,8 +52,21 @@ Original soundtrack
         Ui.Layout.Size(170, 40).StickRight().StickBottom().Move(-10, -10);
         if (Ui.ClickButton(Localisation.Get("Open source libraries")))
         {
-            //TODO this only works on Windows
-            global::System.Diagnostics.Process.Start("explorer", $"\"{Game.ExecutableDirectory}NOTICE.txt\"");
+            string executable;
+            if (global::System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(global::System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                executable = "explorer";
+            }
+            else if(global::System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(global::System.Runtime.InteropServices.OSPlatform.OSX))
+            {
+                executable = "open";
+            }
+            else
+            {
+                executable = "xdg-open";
+            }
+            
+            global::System.Diagnostics.Process.Start(executable, $"\"{Game.ExecutableDirectory}NOTICE.txt\"");
         }
     }
 }

--- a/src/MadnessInteractiveReloaded/User interface/Systems/MainMenuSystem.cs
+++ b/src/MadnessInteractiveReloaded/User interface/Systems/MainMenuSystem.cs
@@ -82,10 +82,7 @@ public class MainMenuSystem : Walgelijk.System
         Ui.Layout.Size(80, 80).StickRight().StickTop().Move(-10, 10);
         if (Ui.ImageButton(Assets.Load<Texture>("textures/ui/discord.png").Value, ImageContainmentMode.Contain))
         {
-            global::System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("https://discord.gg/studio-minus-779898133064056862")
-            {
-                UseShellExecute  = true
-            });
+            MadnessUtils.OpenBrowser("https://discord.gg/studio-minus-779898133064056862");
         }
     }
 

--- a/src/MadnessInteractiveReloaded/User interface/Systems/ModMenuSystem.cs
+++ b/src/MadnessInteractiveReloaded/User interface/Systems/ModMenuSystem.cs
@@ -187,15 +187,27 @@ public class ModMenuSystem : Walgelijk.System
         if (MenuUiUtils.BackButton())
             Game.Scene = MainMenuScene.Load(Game);
 
-#if WINDOWS // windows only because there is no such thing as a "linux file explorer". its all fucked and unique to each user 
         // folder button
         Ui.Layout.FitWidth().MaxWidth(160).Height(40).StickRight().StickBottom().Move(-10);
         Ui.Theme.OutlineWidth(2).Once();
         if (Ui.Button("Mods folder"))
         {
-            global::System.Diagnostics.Process.Start("explorer.exe", ModLoader.Sources.OfType<LocalModCollectionSource>().First().Directory.FullName);
+            string executable;
+            if (global::System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(global::System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                executable = "explorer";
+            }
+            else if(global::System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(global::System.Runtime.InteropServices.OSPlatform.OSX))
+            {
+                executable = "open";
+            }
+            else
+            {
+                executable = "xdg-open";
+            }
+            
+            global::System.Diagnostics.Process.Start(executable, ModLoader.Sources.OfType<LocalModCollectionSource>().First().Directory.FullName);
         }
-#endif
     }
 }
 

--- a/src/MadnessInteractiveReloaded/User interface/Systems/ModMenuSystem.cs
+++ b/src/MadnessInteractiveReloaded/User interface/Systems/ModMenuSystem.cs
@@ -191,23 +191,7 @@ public class ModMenuSystem : Walgelijk.System
         Ui.Layout.FitWidth().MaxWidth(160).Height(40).StickRight().StickBottom().Move(-10);
         Ui.Theme.OutlineWidth(2).Once();
         if (Ui.Button("Mods folder"))
-        {
-            string executable;
-            if (global::System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(global::System.Runtime.InteropServices.OSPlatform.Windows))
-            {
-                executable = "explorer";
-            }
-            else if(global::System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(global::System.Runtime.InteropServices.OSPlatform.OSX))
-            {
-                executable = "open";
-            }
-            else
-            {
-                executable = "xdg-open";
-            }
-            
-            global::System.Diagnostics.Process.Start(executable, ModLoader.Sources.OfType<LocalModCollectionSource>().First().Directory.FullName);
-        }
+            MadnessUtils.OpenExplorer(ModLoader.Sources.OfType<LocalModCollectionSource>().First().Directory.FullName);
     }
 }
 
@@ -242,11 +226,7 @@ public readonly struct ModViewControl(Mod mod) : IControl
                 Ui.Layout.FitHeight().EnqueueConstraint(new AspectRatio(1)).CenterVertical();
                 Ui.Theme.OutlineWidth(0).ForegroundColor(Colors.Transparent).Image(new(Colors.Red, Colors.White)).Once();
                 if (Ui.ImageButton(folder, ImageContainmentMode.Stretch))
-                {
-                    // TODO windows only :(
-                    // TODO get actual mod directory somehow from the local source
-                    global::System.Diagnostics.Process.Start("explorer", local.GetModDirectory(mod.Id)?.FullName ?? local.Directory.FullName);
-                }
+                    MadnessUtils.OpenExplorer(local.GetModDirectory(mod.Id)?.FullName ?? local.Directory.FullName);
             }
         }
         Ui.End();


### PR DESCRIPTION
This uses `xdg-open` and `open` when on Linux and macOS respectively, instead of `explorer`. This should make crash reports function as intended, as well as make the "Mod folder" button work.
Compilation on Linux was also fixed by replacing `MIR` with `.\MIR`, since it previously didn't work according to at least two other users. In theory this should still work on Windows, though I haven't tried it myself.