### PR TITLE
Read and write mods in the appdata directory

### DIFF
--- a/src/MadnessInteractiveReloaded/MIR.csproj
+++ b/src/MadnessInteractiveReloaded/MIR.csproj
@@ -54,7 +54,7 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.11.0" />
 		<PackageReference Include="NativeFileDialogExtendedSharp" Version="0.1.0" />
 		<PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
-		<PackageReference Include="Walgelijk" Version="0.29.9" />
+		<PackageReference Include="Walgelijk" Version="0.29.10" />
 		<PackageReference Include="Walgelijk.AssetManager" Version="0.16.14" />
 		<PackageReference Include="Walgelijk.CommonAssetDeserialisers" Version="0.8.3" />
 		<PackageReference Include="Walgelijk.Localisation" Version="1.1.21" />

--- a/src/MadnessInteractiveReloaded/MadnessInteractiveReloaded.cs
+++ b/src/MadnessInteractiveReloaded/MadnessInteractiveReloaded.cs
@@ -187,6 +187,7 @@ void main()
         MigrateSaveData();
 
         ModLoader.AddSource(new LocalModCollectionSource(new DirectoryInfo(Path.Combine(Game.Main.AppDataDirectory, "mods/"))));
+        ModLoader.AddSource(new LocalModCollectionSource(new DirectoryInfo("./mods")));
 
 #if DEBUG
         Game.Profiling.DrawQuickProfiler = false;

--- a/src/MadnessInteractiveReloaded/MadnessInteractiveReloaded.cs
+++ b/src/MadnessInteractiveReloaded/MadnessInteractiveReloaded.cs
@@ -186,7 +186,7 @@ void main()
         Directory.CreateDirectory(UserData.Paths.CampaignStatsDir);
         MigrateSaveData();
 
-        ModLoader.AddSource(new LocalModCollectionSource(new DirectoryInfo("./mods")));
+        ModLoader.AddSource(new LocalModCollectionSource(new DirectoryInfo(Path.Combine(Game.Main.AppDataDirectory, "mods/"))));
 
 #if DEBUG
         Game.Profiling.DrawQuickProfiler = false;

--- a/src/MadnessInteractiveReloaded/Modding/LocalModCollectionSource.cs
+++ b/src/MadnessInteractiveReloaded/Modding/LocalModCollectionSource.cs
@@ -3,7 +3,6 @@ using System.Collections.Immutable;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Walgelijk;
 
 namespace MIR;
@@ -31,11 +30,23 @@ public class LocalModCollectionSource : IModCollectionSource
     {
         Directory = dir;
         if (!dir.Exists)
-            dir.Create();
+            try
+            {
+                dir.Create();
+            }
+            catch (IOException e)
+            {
+                Logger.Error(e);
+                return;
+            }
+        Logger.Log($"Created local mod source at {dir.FullName}");
     }
 
     public IEnumerable<Mod> ReadAll()
     {
+        if (!Directory.Exists)
+            yield break;
+
         foreach (var file in Directory.GetFiles("meta.json", SearchOption.AllDirectories))
         {
             if (file.Directory == null)

--- a/src/MadnessInteractiveReloaded/Modding/LocalModCollectionSource.cs
+++ b/src/MadnessInteractiveReloaded/Modding/LocalModCollectionSource.cs
@@ -10,7 +10,7 @@ namespace MIR;
 public class LocalModCollectionSource : IModCollectionSource
 {
     public readonly DirectoryInfo Directory;
-
+    public bool IsValid { get; private set; }
     private readonly Dictionary<ModID, DirectoryInfo> modDirs = [];
 
     public readonly static ImmutableArray<string> IgnoredDevFolderNames = [
@@ -29,6 +29,7 @@ public class LocalModCollectionSource : IModCollectionSource
     public LocalModCollectionSource(DirectoryInfo dir)
     {
         Directory = dir;
+
         if (!dir.Exists)
             try
             {
@@ -36,9 +37,12 @@ public class LocalModCollectionSource : IModCollectionSource
             }
             catch (IOException e)
             {
+                IsValid = false;
                 Logger.Error(e);
                 return;
             }
+
+        IsValid = true;
         Logger.Log($"Created local mod source at {dir.FullName}");
     }
 

--- a/src/MadnessInteractiveReloaded/Modding/LocalModCollectionSource.cs
+++ b/src/MadnessInteractiveReloaded/Modding/LocalModCollectionSource.cs
@@ -90,9 +90,10 @@ public class LocalModCollectionSource : IModCollectionSource
 
         var readZip = new ZipArchive(stream);
 
-        if (System.IO.Directory.Exists("./debugout/"))
-            System.IO.Directory.Delete("./debugout/", true);
-        readZip.ExtractToDirectory("./debugout/", true);
+        var debugoutPath = Path.Combine(Game.Main.AppDataDirectory, "debugout/");
+        if (System.IO.Directory.Exists(debugoutPath))
+            System.IO.Directory.Delete(debugoutPath, true);
+        readZip.ExtractToDirectory(debugoutPath, true);
 
         var m = new Mod(readZip);
         modDirs.Add(m.Id, dir);

--- a/src/MadnessInteractiveReloaded/User interface/Systems/ModMenuSystem.cs
+++ b/src/MadnessInteractiveReloaded/User interface/Systems/ModMenuSystem.cs
@@ -191,7 +191,10 @@ public class ModMenuSystem : Walgelijk.System
         Ui.Layout.FitWidth().MaxWidth(160).Height(40).StickRight().StickBottom().Move(-10);
         Ui.Theme.OutlineWidth(2).Once();
         if (Ui.Button("Mods folder"))
-            MadnessUtils.OpenExplorer(ModLoader.Sources.OfType<LocalModCollectionSource>().First().Directory.FullName);
+        {
+            var loc = ModLoader.Sources.OfType<LocalModCollectionSource>().OrderByDescending(s => s.IsValid ? 1 : -1).First().Directory.FullName;
+            MadnessUtils.OpenExplorer(loc);
+        }
     }
 }
 

--- a/src/MadnessInteractiveReloaded/Weapons/WeaponThumbnailCache.cs
+++ b/src/MadnessInteractiveReloaded/Weapons/WeaponThumbnailCache.cs
@@ -19,14 +19,13 @@ public class WeaponThumbnailCache// : Cache<WeaponInstructions, IReadableTexture
     public static readonly WeaponThumbnailCache Instance = new();
     public const int MaxWorkers = 4;
 
-    private static readonly ConcurrentDictionary<string, Worker> workers = [];
-    private const string CacheLocation = "cache/weapons/";
+    private readonly ConcurrentDictionary<string, Worker> workers = [];
+    private readonly string CacheLocation = "cache/weapons/";
 
     public WeaponThumbnailCache()
     {
-        string cachePath = Path.Combine(Game.Main.AppDataDirectory, CacheLocation);
-        if (!Directory.Exists(cachePath))
-            Directory.CreateDirectory(cachePath);
+        CacheLocation = Path.Combine(Game.Main.AppDataDirectory, CacheLocation);
+        Directory.CreateDirectory(CacheLocation);
     }
 
     public IReadableTexture Load(WeaponInstructions obj)
@@ -38,7 +37,7 @@ public class WeaponThumbnailCache// : Cache<WeaponInstructions, IReadableTexture
             return Textures.UserInterface.ApparelButtonBackground.Value;
         }
 
-        string cachedPath = Path.Combine(Game.Main.AppDataDirectory, CacheLocation, obj.Id + ".png");
+        string cachedPath = Path.Combine(CacheLocation, obj.Id + ".png");
 
         if (File.Exists(cachedPath))
         {

--- a/src/MadnessInteractiveReloaded/Weapons/WeaponThumbnailCache.cs
+++ b/src/MadnessInteractiveReloaded/Weapons/WeaponThumbnailCache.cs
@@ -20,12 +20,13 @@ public class WeaponThumbnailCache// : Cache<WeaponInstructions, IReadableTexture
     public const int MaxWorkers = 4;
 
     private static readonly ConcurrentDictionary<string, Worker> workers = [];
-    private const string CacheLocation = "./cache/weapons/";
+    private const string CacheLocation = "cache/weapons/";
 
     public WeaponThumbnailCache()
     {
-        if (!Directory.Exists(CacheLocation))
-            Directory.CreateDirectory(CacheLocation);
+        string cachePath = Path.Combine(Game.Main.AppDataDirectory, CacheLocation);
+        if (!Directory.Exists(cachePath))
+            Directory.CreateDirectory(cachePath);
     }
 
     public IReadableTexture Load(WeaponInstructions obj)
@@ -37,7 +38,7 @@ public class WeaponThumbnailCache// : Cache<WeaponInstructions, IReadableTexture
             return Textures.UserInterface.ApparelButtonBackground.Value;
         }
 
-        string cachedPath = Path.Combine(CacheLocation, obj.Id + ".png");
+        string cachedPath = Path.Combine(Game.Main.AppDataDirectory, CacheLocation, obj.Id + ".png");
 
         if (File.Exists(cachedPath))
         {


### PR DESCRIPTION
This fixes these crashes when the game is installed in a write-protected directory:

* Attempting to write weapon thumbnail pictures into the `cache` folder within the game's directory.
* Attempting to create an empty `mods` folder in the game's directory.
* Attempting to extract zipped mods into a `debugout` folder in the game's directory.

This just moves all those to the appdata folder. From my own basic testing, this pull request (along with mestiez/Walgelijk#23) should finalize fixing #358, as I haven't encountered any other crashes.

There is still the slight problem of needing to migrate mods if any were to exist, which hasn't been implemented yet.

However, there might be a second solution to this, which is to just accept reading mods in the game's directory, as far as I can tell we can just add a second source.
* We'd need to make the game not crash if we fail to add the source (folder doesn't exist and doesn't let us create or read from it).
* The "mods folder" button only opens the first directory. Should we then add the appdata mods folder first before adding the game mods folder?
* As a cool feature, on a write-protected install, this could allow an admin to add mods that can't be uninstalled by the user?? Don't know what the practical purpose of that is but lol.