### PR TITLE
Add SkiaSharp package for Linux

### DIFF
--- a/src/MadnessInteractiveReloaded/MIR.csproj
+++ b/src/MadnessInteractiveReloaded/MIR.csproj
@@ -53,6 +53,7 @@
 		<PackageReference Include="Lib.Harmony" Version="2.3.3" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.11.0" />
 		<PackageReference Include="NativeFileDialogExtendedSharp" Version="0.1.0" />
+		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.9" />
 		<PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
 		<PackageReference Include="Walgelijk" Version="0.29.10" />
 		<PackageReference Include="Walgelijk.AssetManager" Version="0.16.14" />


### PR DESCRIPTION
Adding SkiaSharp.NativeAssets.Linux as a package under MIR.csproj seems to fix the missing libSkiaSharp shared library issue when loading the game on Linux after building.

I have only tested this on Linux Mint 22 so far. I have not been able to test this on Windows yet.