### PR TITLE
Revert Harmony from submodule back to nuget dep

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "src/BigGustave"]
 	path = src/BigGustave
 	url = https://github.com/mestiez/BigGustave
-[submodule "src/Harmony"]
-	path = src/Harmony
-	url = https://github.com/pardeike/Harmony

--- a/src/MIR.sln
+++ b/src/MIR.sln
@@ -24,8 +24,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BigGustave", "BigGustave\src\BigGustave\BigGustave.csproj", "{043967FF-664B-4BA4-8E21-F519BF8684CF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmony", "Harmony\Harmony\Harmony.csproj", "{84CD82B6-A5A0-46D9-BB3C-93B51510C280}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -156,34 +154,6 @@ Global
 		{043967FF-664B-4BA4-8E21-F519BF8684CF}.ReleaseThin|Any CPU.Build.0 = Release|Any CPU
 		{043967FF-664B-4BA4-8E21-F519BF8684CF}.ReleaseThin|x64.ActiveCfg = Release|Any CPU
 		{043967FF-664B-4BA4-8E21-F519BF8684CF}.ReleaseThin|x64.Build.0 = Release|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.Debug|Any CPU.ActiveCfg = DebugThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.Debug|Any CPU.Build.0 = DebugThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.Debug|x64.ActiveCfg = DebugThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.Debug|x64.Build.0 = DebugThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.DebugFat|Any CPU.ActiveCfg = DebugFat|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.DebugFat|Any CPU.Build.0 = DebugFat|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.DebugFat|x64.ActiveCfg = DebugFat|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.DebugFat|x64.Build.0 = DebugFat|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.DebugThin|Any CPU.ActiveCfg = DebugThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.DebugThin|Any CPU.Build.0 = DebugThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.DebugThin|x64.ActiveCfg = DebugThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.DebugThin|x64.Build.0 = DebugThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.Release|Any CPU.ActiveCfg = ReleaseThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.Release|Any CPU.Build.0 = ReleaseThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.Release|x64.ActiveCfg = ReleaseThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.Release|x64.Build.0 = ReleaseThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseFat|Any CPU.ActiveCfg = ReleaseFat|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseFat|Any CPU.Build.0 = ReleaseFat|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseFat|x64.ActiveCfg = ReleaseFat|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseFat|x64.Build.0 = ReleaseFat|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseRef|Any CPU.ActiveCfg = ReleaseRef|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseRef|Any CPU.Build.0 = ReleaseRef|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseRef|x64.ActiveCfg = ReleaseRef|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseRef|x64.Build.0 = ReleaseRef|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseThin|Any CPU.ActiveCfg = ReleaseThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseThin|Any CPU.Build.0 = ReleaseThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseThin|x64.ActiveCfg = ReleaseThin|Any CPU
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280}.ReleaseThin|x64.Build.0 = ReleaseThin|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -193,7 +163,6 @@ Global
 		{72C81428-938D-4460-8A7F-1355FC30B6F1} = {8836B58D-39C2-43BB-970A-5F620685A10A}
 		{D641958B-DE2B-4689-AC1B-BA34460FFC69} = {AAEB9C5C-5279-479C-A0D5-A467B24B71DD}
 		{043967FF-664B-4BA4-8E21-F519BF8684CF} = {F0D7E041-7E63-478F-AB01-37385E932D3A}
-		{84CD82B6-A5A0-46D9-BB3C-93B51510C280} = {F0D7E041-7E63-478F-AB01-37385E932D3A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6593244E-952A-4036-9977-D1828F875836}

--- a/src/MadnessInteractiveReloaded.Test/MIR.Test.csproj
+++ b/src/MadnessInteractiveReloaded.Test/MIR.Test.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="7.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="System.Text.Json" Version="9.0.0" />
+		<PackageReference Include="System.Text.Json" Version="9.0.1" />
 		<PackageReference Include="xunit" Version="2.9.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MadnessInteractiveReloaded/MIR.csproj
+++ b/src/MadnessInteractiveReloaded/MIR.csproj
@@ -39,19 +39,20 @@
 	</PropertyGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="MIR --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(OutDir)" />
+		<Exec Command=".\MIR --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(OutDir)" />
 	</Target>
 	
 	<Target Name="PostPublish" AfterTargets="Publish">
-		<Exec Command="MIR --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(PublishDir)" />
+		<Exec Command=".\MIR --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(PublishDir)" />
 	</Target>
 
 	<ItemGroup>
+		<PackageReference Include="Lib.Harmony" Version="2.3.5" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
 		<PackageReference Include="NativeFileDialogExtendedSharp" Version="0.1.0" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
 		<PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
-		<PackageReference Include="System.Text.Json" Version="9.0.0" />
+		<PackageReference Include="System.Text.Json" Version="9.0.1" />
 		<PackageReference Include="Walgelijk" Version="0.30.0" />
 		<PackageReference Include="Walgelijk.AssetManager" Version="0.17.0" />
 		<PackageReference Include="Walgelijk.CommonAssetDeserialisers" Version="0.9.0" />
@@ -79,7 +80,6 @@
 	
 	<ItemGroup>
 		<ProjectReference Include="..\BigGustave\src\BigGustave\BigGustave.csproj" />
-		<ProjectReference Include="..\Harmony\Harmony\Harmony.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Harmony was temporarily turned into a submodule/local dependency alongside the net9.0 upgrade, because its Nuget package hadn't been updated to add net9.0 support. Last week or so, it finally pushed a new release that has net9.0 support, so having it as a submodule is not needed anymore: https://github.com/pardeike/Harmony/releases/tag/v2.3.4.0
* This fixes the issue where I'm dumb as hell because I haven't figured out how to compile the game alongside Harmony on linux without errors lol
* Pretty please test the thing on your end!!! thank you.
* The commit sneaks back in the tiny linux compilation fix which ??? had been removed for some reason (see line 42, 46 of MIR.csproj). If this was reverted for good reasons (because it caused issues on other platforms or whatever?) PLEASE TELL ME because I'm not aware of any such issues. I'm putting it back there so that it doesn't throw an error on my Linux.