### PR TITLE
Add github actions for automated building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,93 @@
+name: Build MIR
+
+on:
+  push:
+    branches:
+      - main
+    tags:        
+      - '*'
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  build-linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Initialize and update git submodules
+        run: |
+          git submodule init
+          git submodule update --remote
+
+      - name: Set up .NET SDK 9
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.x'
+
+      - name: Build the project
+        working-directory: ./src/MadnessInteractiveReloaded
+        run: dotnet build --runtime linux-x64 -c Release --self-contained true
+
+      - name: Compress artifacts
+        working-directory: ./src/MadnessInteractiveReloaded/bin/Release/net9.0/linux-x64
+        run: |
+          zip ../MIR-linux-x64.zip -r *
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: MIR-linux-x64.zip
+          path: |
+            ./src/MadnessInteractiveReloaded/bin/Release/net9.0/MIR-linux-x64.zip
+      
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ./src/MadnessInteractiveReloaded/bin/Release/net9.0/MIR-linux-x64.zip
+
+  build-windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - name: Install 7z
+        uses: milliewalky/setup-7-zip@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Initialize and update git submodules
+        run: |
+          git submodule init
+          git submodule update --remote
+
+      - name: Set up .NET SDK 9
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.x'
+
+      - name: Build the project
+        working-directory: ./src/MadnessInteractiveReloaded
+        run: dotnet build --runtime win-x64 -c Release
+
+      - name: Compress artifacts
+        working-directory: ./src/MadnessInteractiveReloaded/bin/Release/net9.0/win-x64
+        run: |
+          7z a ../MIR-win-x64.zip * 
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: MIR-win-x64.zip
+          path: |
+            ./src/MadnessInteractiveReloaded/bin/Release/net9.0/MIR-win-x64.zip
+      
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ./src/MadnessInteractiveReloaded/bin/Release/net9.0/MIR-win-x64.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   build-linux:
@@ -31,25 +30,25 @@ jobs:
 
       - name: Build the project
         working-directory: ./src/MadnessInteractiveReloaded
-        run: dotnet build --runtime linux-x64 -c Release --self-contained true
+        run: dotnet publish -p:PublishProfile=Linux_Release_x64
 
       - name: Compress artifacts
-        working-directory: ./src/MadnessInteractiveReloaded/bin/Release/net9.0/linux-x64
+        working-directory: ./src/MadnessInteractiveReloaded/bin/Release/Linux/net9.0/publish
         run: |
           zip ../MIR-linux-x64.zip -r *
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MIR-linux-x64.zip
+          name: MIR-linux-x64
           path: |
-            ./src/MadnessInteractiveReloaded/bin/Release/net9.0/MIR-linux-x64.zip
+            ./src/MadnessInteractiveReloaded/bin/Release/Linux/net9.0/MIR-linux-x64.zip
       
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ./src/MadnessInteractiveReloaded/bin/Release/net9.0/MIR-linux-x64.zip
+          files: ./src/MadnessInteractiveReloaded/bin/Release/Linux/net9.0/MIR-linux-x64.zip
 
   build-windows:
     name: Windows
@@ -57,6 +56,7 @@ jobs:
     steps:
       - name: Install 7z
         uses: milliewalky/setup-7-zip@v2
+        
       - name: Checkout code
         uses: actions/checkout@v3
 
@@ -72,22 +72,22 @@ jobs:
 
       - name: Build the project
         working-directory: ./src/MadnessInteractiveReloaded
-        run: dotnet build --runtime win-x64 -c Release
+        run: dotnet publish -p:PublishProfile=Windows_Release_x64
 
       - name: Compress artifacts
-        working-directory: ./src/MadnessInteractiveReloaded/bin/Release/net9.0/win-x64
+        working-directory: ./src/MadnessInteractiveReloaded/bin/Release/Windows/net9.0/publish
         run: |
           7z a ../MIR-win-x64.zip * 
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MIR-win-x64.zip
+          name: MIR-win-x64
           path: |
-            ./src/MadnessInteractiveReloaded/bin/Release/net9.0/MIR-win-x64.zip
+            ./src/MadnessInteractiveReloaded/bin/Release/Windows/net9.0/MIR-win-x64.zip
       
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ./src/MadnessInteractiveReloaded/bin/Release/net9.0/MIR-win-x64.zip
+          files: ./src/MadnessInteractiveReloaded/bin/Release/Windows/net9.0/MIR-win-x64.zip

--- a/src/MadnessInteractiveReloaded/MIR.csproj
+++ b/src/MadnessInteractiveReloaded/MIR.csproj
@@ -15,6 +15,7 @@
 		<DebugType>embedded</DebugType>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Platforms>AnyCPU;x64</Platforms>
+		<RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
 	</PropertyGroup>
 	
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -37,13 +38,17 @@
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
 		<DebugType>portable</DebugType>
 	</PropertyGroup>
+	<PropertyGroup>
+		<CommandPrefix Condition="'$(OS)' != 'Unix'">.\</CommandPrefix>
+ 		<CommandPrefix Condition="'$(OS)' == 'Unix'">./</CommandPrefix>
+	</PropertyGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command=".\MIR --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(OutDir)" />
-	</Target>
+  		<Exec Command="$(CommandPrefix)MIR  --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(OutDir)" />
+  	</Target>
 	
 	<Target Name="PostPublish" AfterTargets="Publish">
-		<Exec Command=".\MIR --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(PublishDir)" />
+		<Exec Command="$(CommandPrefix)MIR --mode pack --input &quot;$(ProjectDir)base&quot; --output resources/base.waa" WorkingDirectory="$(PublishDir)" />
 	</Target>
 
 	<ItemGroup>

--- a/src/MadnessInteractiveReloaded/Properties/PublishProfiles/Linux_Release_x64.pubxml
+++ b/src/MadnessInteractiveReloaded/Properties/PublishProfiles/Linux_Release_x64.pubxml
@@ -4,16 +4,16 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration>Debug</Configuration>
+    <Configuration>Release</Configuration>
     <Platform>x64</Platform>
-    <OutDir>bin\Debug\Windows\net9.0\publish\</OutDir>
+    <PublishDir>bin\Release\Linux\net9.0\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <TargetFramework>net9.0</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <PublishSingleFile>true</PublishSingleFile>
+    <PublishSingleFile>false</PublishSingleFile>
     <PublishReadyToRun>false</PublishReadyToRun>
-    <DefineConstants>DEBUG</DefineConstants>
+    <DefineConstants>RELEASE</DefineConstants>
     <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## :link:  Related Issues
Closes #425 

## :grey_exclamation:  Summary
The goal of this PR is to introduce GitHub Actions for automated building of the game for Windows and Linux.

## :scroll:  Description
The workflow:
1. Builds the game for Windows and Linux
2. Compresses it using `xz` (this should help reduce the file but may not be Windows-friendly)
3. Uploads the artifacts
4. (On tag pushes) Creates a new release for tag (if not already present) and attaches the binaries to it

## :speech_balloon:  Talking points
Stuff up for discussion/changing:
- The compression can be changed to zip to make it easier for Windows users
- The artifacts are currently named after the system but perhaps could include the version
- The workflow may be configured to run only for the tag pushes (and not for other PRs due to Actions limits like time and size - the retention can be configured though), although I thought it may help with testing the changes - it could be easily extended to run tests
- I have modified the `.csproj` to conditionally change the way in which the `MRI` is invoked, since the current setup does not work on Linux and the Linux one does not work on Windows, it could perhaps be handled differently

## :grey_question:  Additional info
- :exclamation: **Since this is a workflow file (sensitive) you should examine it carefully - make sure that you understand what it does and that it is safe**
- You can preview the generated release in [my fork](https://github.com/Fruktus/madness-interactive-reloaded/releases/tag/ci-demo) - this can be customized or manually edited
- You can view the sample run in PR with attached artifacts [here](https://github.com/Fruktus/madness-interactive-reloaded/actions/runs/13465992061) 
- I am open to all suggestions, if you'd like to change it up in any way or would need clarifications on something let me know :smile_cat: 
- I have set the build to bundle dotnet runtime, it seems to be the same for the official releases